### PR TITLE
Update mailosaur.rb

### DIFF
--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -3,6 +3,7 @@ require 'rest_client'
 require 'json'
 require 'rest_client'
 require 'securerandom'
+require 'date'
 require "#{File.dirname(__FILE__)}/mailosaur/email"
 
 # Main class to access Mailosaur.com api.


### PR DESCRIPTION
Require _Date_ on gem. Receiving ``NameError: uninitialized constant Email::DateTime`` without requiring on my spec_helper. 
