### PR TITLE
Updated Readme example code to actually work :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mailbox = Mailosaur.new(mailbox,apikey)
 
 emails = mailbox.getEmailsByRecipient('anything.1eaaeef6@mailosaur.in')
 
-assert_equal('something', emails[0].Subject, 'The subject should be something')
+assert_equal('something', emails[0].subject, 'The subject should be something')
 ```
 ##Api
 


### PR DESCRIPTION
```ruby
assert_equal('something', emails[0].Subject, 'The subject should be something')
```

Subject is not a valid call here, you need to use the following

```ruby
assert_equal('something', emails[0].subject, 'The subject should be something')
```

This is a prime example of why we need to merge in the ruby styling PR.