### PR TITLE
Proper Timeout Setting Fix 

### DIFF
--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -3,10 +3,10 @@ require_relative 'helper.rb'
 class Mailosaur
   attr_reader :message
 
-  def initialize(mailbox, apiKey)
+  def initialize(mailbox, apiKey, timeout=20)
     @mailbox  = ENV['MAILOSAUR_MAILBOX'] || mailbox
     @api_key  = ENV['MAILOSAUR_APIKEY']  || apiKey
-    @timeout  = ENV['MAILOSAUR_TIMEOUT'].to_i || 20
+    @timeout  = timeout
     @base_uri = 'https://mailosaur.com/v2'
     @message  = MessageGenerator.new
   end


### PR DESCRIPTION
This would be a more appropriate solution as it avoids any nasty string conversion of an ENV variable and instead takes the input upon object creation. You still get the benefit of having a default value of '20' if not passed by the user. 

```ruby
mailbox    = Mailosaur.new(mailbox, api_key, timeout)
OR 
mailbox    = Mailosaur.new(mailbox, api_key)
```

both will work in this new design. 