### PR TITLE
Remove Timeouts

### DIFF
--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -3,10 +3,9 @@ require_relative 'helper.rb'
 class Mailosaur
   attr_reader :message
 
-  def initialize(mailbox, apiKey, timeout=20)
+  def initialize(mailbox, apiKey)
     @mailbox  = ENV['MAILOSAUR_MAILBOX'] || mailbox
     @api_key  = ENV['MAILOSAUR_APIKEY']  || apiKey
-    @timeout  = timeout
     @base_uri = 'https://mailosaur.com/v2'
     @message  = MessageGenerator.new
   end
@@ -19,7 +18,7 @@ class Mailosaur
     search_criteria['key']     = @api_key
     search_criteria['mailbox'] = @mailbox
     response = send_get_emails_request(search_criteria)
-    if response.length > 2
+    if !response.nil? && response.length > 2
       data   = JSON.parse(response.body)
       data.map { |em| Email.new(em) }
     else
@@ -108,16 +107,6 @@ class Mailosaur
   private
 
   def send_get_emails_request(search_criteria)
-    r = ''
-    begin
-      Timeout::timeout(@timeout) {
-        until r.length > 2 && !r.nil?
-          r = RestClient.get("#{@base_uri}/emails", {:params => search_criteria})
-        end
-        r
-      }
-    rescue Timeout::Error
-      ''
-    end
+    RestClient.get("#{@base_uri}/emails", {:params => search_criteria})
   end
 end


### PR DESCRIPTION
//This may be controversial as it changes a design pattern of your library, but I would ask your team to take the time to really consider the proposal. 

Background: I expect querying a mailbox to return back the state of the mailbox at the time of the request. It is undesirable for the library to enter a loop which anticipates an alternate state. Moreover, the looping mechanism only applies to empty inboxes. As such, the goal of guaranteeing a new email has arrived is only valuable to the empty-inbox use-case. If you have an inbox which already has data in it, you will be immediately returned the results with no certainty that said results contain the new email you are waiting for.

A developer will always need to wrap their inbox lookups in a loop that analyze the resulting emails to check if their new email has arrived (perhaps looking for a timestamp, a certain subject, or a certain sender). If this is the case, the timeout code gets in the way of this as it does unnecessary extra looping for empty inboxes. 

This updated code is cleaner and leaves the looping to the developer. An example of analyzing email results is below

```ruby
  10.times do |i|
    emails = @mailbox.get_emails_by_recipient(inbox)
    if emails.is_a?(Array) && emails.map(&:subject).include?(subject)
      break
    else
      sleep(2)
      raise "expected email not received for #{inbox}" if i == 9
    end
  end```