### PR TITLE
Use credentials in environment variable as default parameters

### DIFF
--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -3,9 +3,9 @@ require_relative 'helper.rb'
 class Mailosaur
   attr_reader :message
 
-  def initialize(mailbox = ENV['MAILOSAUR_MAILBOX'], apiKey = ENV['MAILOSAUR_APIKEY'])
-    @mailbox  = mailbox
-    @api_key  = apiKey
+  def initialize(mailbox = nil, apiKey = nil)
+    @mailbox  = ENV['MAILOSAUR_MAILBOX'] || mailbox
+    @api_key  = ENV['MAILOSAUR_APIKEY']  || apiKey
     @base_uri = 'https://mailosaur.com/v2'
     @message  = MessageGenerator.new
   end

--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -3,9 +3,9 @@ require_relative 'helper.rb'
 class Mailosaur
   attr_reader :message
 
-  def initialize(mailbox, apiKey)
-    @mailbox  = ENV['MAILOSAUR_MAILBOX'] || mailbox
-    @api_key  = ENV['MAILOSAUR_APIKEY']  || apiKey
+  def initialize(mailbox = ENV['MAILOSAUR_MAILBOX'], apiKey = ENV['MAILOSAUR_APIKEY'])
+    @mailbox  = mailbox
+    @api_key  = apiKey
     @base_uri = 'https://mailosaur.com/v2'
     @message  = MessageGenerator.new
   end


### PR DESCRIPTION
Allows to create a new instance of `Mailosaur` by using environment variables directly.

To use credentials environment variables we are forced to do a `Mailosaur.new(nil, nil)` unless ruby throws `wrong number of arguments (given 0, expected 2) (ArgumentError)`.